### PR TITLE
Update pylint.yaml

### DIFF
--- a/.github/workflows/pylint.yaml
+++ b/.github/workflows/pylint.yaml
@@ -23,4 +23,4 @@ jobs:
         pip install pylint
     - name: Analysing the code with pylint
       run: |
-        pylint --disable=C0103,C0114,C0115,C0116,C0209,R0801,R0903,R0205,R1737,R0913,W1202,W0246,W0223,W0221,W0104,W0102,W0613,E0401,E0611,E1101 $(git ls-files 'src/pool.py')
+        pylint --max-line-length=120 --disable=C0103,C0114,C0115,C0116,C0209,R0801,R0903,R0205,R1737,R0913,W1202,W0246,W0223,W0221,W0104,W0102,W0613,E0401,E0611,E1101 $(git ls-files 'src/pool.py')


### PR DESCRIPTION
# Pull Request

## Description

Extend max-line-length to 120 chars used by Pylint checks.

## Type of Change

- [x] Continous Integration
